### PR TITLE
implement chapter reference

### DIFF
--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -144,7 +144,7 @@ DocLibraryPresenter class >> searchActionDisplayOn: occurenceDisplay [
 DocLibraryPresenter class >> searchBar [
 
 	| occurenceDisplay searchText occurenceCollection |
-	occurenceCollection := searchInput owner docSearchObject nbOccurence.
+	occurenceCollection := OrderedCollection new.
 	indexChapter := 1.
 	occurence := 1.
 	occurenceDisplay := SpTextInputFieldPresenter new beNotEditable.
@@ -153,6 +153,7 @@ DocLibraryPresenter class >> searchBar [
 		searchText = searchInput text
 			ifTrue: [ [self nextAction: occurenceCollection on: occurenceDisplay] on: SubscriptOutOfBounds  do: [ "nothing" ] ]
 			ifFalse: [ [self searchAction: occurence  on: occurenceDisplay.
+						  occurenceCollection := searchInput owner docSearchObject nbOccurence.
 						  searchText := searchInput text] on: SubscriptOutOfBounds  do: [ "nothing" ] ] ].
 
 	^ SpBoxLayout newHorizontal

--- a/src/DocumentationSupport-UI/DocRichTextComposer.class.st
+++ b/src/DocumentationSupport-UI/DocRichTextComposer.class.st
@@ -146,7 +146,7 @@ DocRichTextComposer >> visitLink: aLink [
 							 actOnClickBlock: [ WebBrowser openOn: aLink url printString ] ].
 	(self isRef: aLink) ifTrue: [ 
 		attribute := TextAction new
-			             actOnClickBlock: [ (DocChapter chapterAt: (aLink url path segments at: 2))
+			             actOnClickBlock: [ (DocChapter dictionnaryOfChaptersAt: (aLink url path segments at: 2))
 					             				  asPresenter openWithSpec ];
 			            							  yourself ].
 	(self isInclude: aLink) ifTrue: [ 

--- a/src/DocumentationSupport-UI/DocRichTextComposer.class.st
+++ b/src/DocumentationSupport-UI/DocRichTextComposer.class.st
@@ -85,6 +85,24 @@ DocRichTextComposer >> indexOfOccurence: aText [
 	^ index
 ]
 
+{ #category : #testing }
+DocRichTextComposer >> isInclude: aLink [
+
+	^ (aLink url path segments at: 1) = 'include:'
+]
+
+{ #category : #testing }
+DocRichTextComposer >> isRef: aLink [
+
+	^ (aLink url path segments at: 1) = 'ref:'
+]
+
+{ #category : #testing }
+DocRichTextComposer >> isWeb: aLink [
+
+	^ (aLink url path segments at: 1) = 'http' or: [ (aLink url path segments at: 1) = 'https' ]
+]
+
 { #category : #visiting }
 DocRichTextComposer >> visit: aDocument [
 	| text |
@@ -107,34 +125,35 @@ DocRichTextComposer >> visitExternalLink: aLink [
 			[ attribute := TextAction new actOnClickBlock: [ self class browse: aLink urlEntry ] ].
 	url scheme = #ref
 		ifTrue:
-			[ attribute := TextAction new actOnClickBlock: [ executor openReference: aLink urlEntry ] ].
+			[ attribute := TextAction new actOnClickBlock: [ executor openReference: aLink urlEntry] ].
 	url scheme = #include
 		ifTrue:
 			[ attribute := TextAction new actOnClickBlock: [ executor openReference: aLink urlEntry ] ].
 	attribute
 		ifNotNil:
-			[ canvas includeAttribute: attribute in: [ self visitLink: aLink ] ]
+			[ canvas includeAttribute: attribute in: [ super visitLink: aLink ] ]
 		ifNil: [ self visitLink: aLink ]
+
 ]
 
 { #category : #visiting }
 DocRichTextComposer >> visitLink: aLink [
+
 	| attribute |
 	attribute := nil.
-	(#(http https) includes: aLink url scheme )
-		ifTrue: [ attribute := TextAction new actOnClickBlock: [ WebBrowser openOn: aLink url printString ]].
-		
-	aLink url scheme = #browse
-		ifTrue:
-			[ attribute := TextAction new actOnClickBlock: [ self class browse: aLink url ] ].
-	aLink url scheme = #ref
-		ifTrue:
-			[ attribute := TextAction new actOnClickBlock: [ executor openReference: aLink url ] ].
-	aLink url scheme = #include
-		ifTrue:
-			[ attribute := TextAction new actOnClickBlock: [ executor openReference: aLink url ] ].
+	(self isWeb: aLink) ifTrue: [ 
+		attribute := TextAction new
+							 actOnClickBlock: [ WebBrowser openOn: aLink url printString ] ].
+	(self isRef: aLink) ifTrue: [ 
+		attribute := TextAction new
+			             actOnClickBlock: [ (DocChapter test at: '75d2wxrfmurei9q5bzs8hskrp')
+					             				  asPresenter openWithSpec ];
+			            							  yourself ].
+	(self isInclude: aLink) ifTrue: [ 
+		attribute := TextAction new
+							 actOnClickBlock: [ "to implement" ] ].
 	attribute
-		ifNotNil:
-			[ canvas includeAttribute: attribute in: [ super visitLink: aLink ] ]
+		ifNotNil: [ 
+		canvas includeAttribute: attribute in: [ super visitLink: aLink ] ]
 		ifNil: [ super visitLink: aLink ]
 ]

--- a/src/DocumentationSupport-UI/DocRichTextComposer.class.st
+++ b/src/DocumentationSupport-UI/DocRichTextComposer.class.st
@@ -146,7 +146,7 @@ DocRichTextComposer >> visitLink: aLink [
 							 actOnClickBlock: [ WebBrowser openOn: aLink url printString ] ].
 	(self isRef: aLink) ifTrue: [ 
 		attribute := TextAction new
-			             actOnClickBlock: [ (DocChapter test at: '75d2wxrfmurei9q5bzs8hskrp')
+			             actOnClickBlock: [ (DocChapter chapterAt: (aLink url path segments at: 2))
 					             				  asPresenter openWithSpec ];
 			            							  yourself ].
 	(self isInclude: aLink) ifTrue: [ 

--- a/src/DocumentationSupport-UI/DocRichTextComposer.class.st
+++ b/src/DocumentationSupport-UI/DocRichTextComposer.class.st
@@ -141,19 +141,20 @@ DocRichTextComposer >> visitLink: aLink [
 
 	| attribute |
 	attribute := nil.
+	
 	(self isWeb: aLink) ifTrue: [ 
 		attribute := TextAction new
 							 actOnClickBlock: [ WebBrowser openOn: aLink url printString ] ].
+						
 	(self isRef: aLink) ifTrue: [ 
 		attribute := TextAction new
-			             actOnClickBlock: [ (DocChapter dictionnaryOfChaptersAt: (aLink url path segments at: 2))
-					             				  asPresenter openWithSpec ];
-			            							  yourself ].
+			             actOnClickBlock: [ [(DocChapter dictionnaryOfChaptersAt: (aLink url path segments at: 2))
+					             				  asPresenter openWithSpec ;
+			            							  yourself] on: KeyNotFound do: [ "nothing" ]]].
 	(self isInclude: aLink) ifTrue: [ 
 		attribute := TextAction new
 							 actOnClickBlock: [ "to implement" ] ].
 	attribute
-		ifNotNil: [ 
-		canvas includeAttribute: attribute in: [ super visitLink: aLink ] ]
+		ifNotNil: [ canvas includeAttribute: attribute in: [ super visitLink: aLink ] ]
 		ifNil: [ super visitLink: aLink ]
 ]

--- a/src/DocumentationSupport/DocBook.class.st
+++ b/src/DocumentationSupport/DocBook.class.st
@@ -53,6 +53,7 @@ DocBook >> addNewChapter [
 	
 	newChapter := self addNewChapterWithoutNotification.
 	library aspectChanged: #chapters.
+	DocChapter addDictionaryOfChapters: newChapter.
 	^ newChapter
 ]
 

--- a/src/DocumentationSupport/DocBook.class.st
+++ b/src/DocumentationSupport/DocBook.class.st
@@ -101,6 +101,7 @@ DocBook >> children [
 { #category : #removing }
 DocBook >> delete [ 
 
+	self chapters do: [ :chapter | chapter ifNotNil: [ self deleteChapter: chapter ] ].
 	self library deleteBook: self.
 	self makeDirty.
 	library aspectChanged: #chapters.
@@ -117,6 +118,7 @@ DocBook >> deleteChapter: aChapter [
 	chapters remove: aChapter.
 	chapters do: [ :each | 
 		each chapterRemoved: aChapter ].
+	DocChapter removeDictionaryOfChapters: aChapter.
 	library aspectChanged: #chapters.
 
 	

--- a/src/DocumentationSupport/DocChapter.class.st
+++ b/src/DocumentationSupport/DocChapter.class.st
@@ -237,6 +237,7 @@ DocChapter >> printOn: aStream [
 DocChapter >> readMetadataFrom: aDictionary [
 
 	super readMetadataFrom: aDictionary.
+	DocChapter addDictionaryOfChapters: self.
 	aDictionary at: #nextChapter ifPresent: [ :value | nextChapter := DocParentReference key: value ].	
 	
 	

--- a/src/DocumentationSupport/DocChapter.class.st
+++ b/src/DocumentationSupport/DocChapter.class.st
@@ -21,8 +21,8 @@ DocChapter class >> addDictionaryOfChapters: aChapter [
 ]
 
 { #category : #tests }
-DocChapter class >> test [
-	^ dictionaryOfChapters
+DocChapter class >> chapterAt: aKey [
+	^ dictionaryOfChapters at: aKey
 ]
 
 { #category : #accessing }

--- a/src/DocumentationSupport/DocChapter.class.st
+++ b/src/DocumentationSupport/DocChapter.class.st
@@ -25,6 +25,12 @@ DocChapter class >> dictionnaryOfChaptersAt: aKey [
 	^ dictionaryOfChapters at: aKey
 ]
 
+{ #category : #adding }
+DocChapter class >> removeDictionaryOfChapters: aChapter [
+	dictionaryOfChapters ifNotNil: [ dictionaryOfChapters removeKey: aChapter key ].
+
+]
+
 { #category : #accessing }
 DocChapter >> aBookOrChapter [
 

--- a/src/DocumentationSupport/DocChapter.class.st
+++ b/src/DocumentationSupport/DocChapter.class.st
@@ -91,6 +91,7 @@ DocChapter >> addNewChapter [
 	newChapter := self book addNewChapterWithoutNotification. 
 	newChapter parent: self.
 	library aspectChanged: #chapters.
+	DocChapter addDictionaryOfChapters: newChapter.
 	^ newChapter
 ]
 

--- a/src/DocumentationSupport/DocChapter.class.st
+++ b/src/DocumentationSupport/DocChapter.class.st
@@ -8,8 +8,17 @@ Class {
 		'source',
 		'nextChapter'
 	],
+	#classInstVars : [
+		'dictionaryOfChapters'
+	],
 	#category : #'DocumentationSupport-Model'
 }
+
+{ #category : #adding }
+DocChapter class >> addDictionaryOfChapters: aChapter [
+	dictionaryOfChapters ifNil: [ dictionaryOfChapters := OrderedDictionary new ].
+	dictionaryOfChapters at: aChapter key put: aChapter
+]
 
 { #category : #accessing }
 DocChapter >> aBookOrChapter [
@@ -162,7 +171,8 @@ DocChapter >> initialize [
 
 	super initialize.
 	
-	source := ''
+	source := ''.
+	self class addDictionaryOfChapters: self
 ]
 
 { #category : #testing }

--- a/src/DocumentationSupport/DocChapter.class.st
+++ b/src/DocumentationSupport/DocChapter.class.st
@@ -20,6 +20,11 @@ DocChapter class >> addDictionaryOfChapters: aChapter [
 	dictionaryOfChapters at: aChapter key put: aChapter
 ]
 
+{ #category : #tests }
+DocChapter class >> test [
+	^ dictionaryOfChapters
+]
+
 { #category : #accessing }
 DocChapter >> aBookOrChapter [
 

--- a/src/DocumentationSupport/DocChapter.class.st
+++ b/src/DocumentationSupport/DocChapter.class.st
@@ -20,8 +20,8 @@ DocChapter class >> addDictionaryOfChapters: aChapter [
 	dictionaryOfChapters at: aChapter key put: aChapter
 ]
 
-{ #category : #tests }
-DocChapter class >> chapterAt: aKey [
+{ #category : #accessing }
+DocChapter class >> dictionnaryOfChaptersAt: aKey [
 	^ dictionaryOfChapters at: aKey
 ]
 

--- a/src/DocumentationSupport/DocChapter.class.st
+++ b/src/DocumentationSupport/DocChapter.class.st
@@ -177,7 +177,6 @@ DocChapter >> initialize [
 	super initialize.
 	
 	source := ''.
-	self class addDictionaryOfChapters: self
 ]
 
 { #category : #testing }

--- a/src/DocumentationSupport/DocModelWithKey.class.st
+++ b/src/DocumentationSupport/DocModelWithKey.class.st
@@ -259,7 +259,7 @@ DocModelWithKey >> title: anObject [
 
 { #category : #serialization }
 DocModelWithKey >> writeStonKeysTo: aDictionary [ 
-
+	self halt.
 	aDictionary
 		at: #title put: title;
 		at: #key put: key;

--- a/src/DocumentationSupport/DocModelWithKey.class.st
+++ b/src/DocumentationSupport/DocModelWithKey.class.st
@@ -115,7 +115,6 @@ DocModelWithKey >> key [
 DocModelWithKey >> key: anObject [
 
 	key := anObject.
-	self halt.
 	self makeDirty.
 	self aspectChanged: #title
 
@@ -259,7 +258,6 @@ DocModelWithKey >> title: anObject [
 
 { #category : #serialization }
 DocModelWithKey >> writeStonKeysTo: aDictionary [ 
-	self halt.
 	aDictionary
 		at: #title put: title;
 		at: #key put: key;

--- a/src/DocumentationSupport/DocModelWithKey.class.st
+++ b/src/DocumentationSupport/DocModelWithKey.class.st
@@ -115,7 +115,7 @@ DocModelWithKey >> key [
 DocModelWithKey >> key: anObject [
 
 	key := anObject.
-	
+	self halt.
 	self makeDirty.
 	self aspectChanged: #title
 


### PR DESCRIPTION
We can access at all chapters in dictionnary of class side of DocChapter.
We add chapter in this dictionnary when :
- we add new chapter in DocBook
- we read meta data

In DocRichTextComposer for the reference, we change the chapter into a ChapterPresenter and them open it when we click on the reference.