### PR TITLE
Add shortcuts

### DIFF
--- a/src/DocumentationSupport-Search-Tests/DocSearchEnvironmentTest.class.st
+++ b/src/DocumentationSupport-Search-Tests/DocSearchEnvironmentTest.class.st
@@ -87,7 +87,7 @@ DocSearchEnvironmentTest >> testFirstOccurenceOfFourthChapter [
 	self assert: docSearchEnv currentEntryIndex equals: 2.
 	self assert: docSearchEnv resultEntries size equals: 4.
 	self assert: docSearchEnv currentResultEntry chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv currentResultEntry startPosition equals: 12
+	self assert: docSearchEnv currentResultEntry startPosition equals: 11
 	
 ]
 
@@ -101,7 +101,7 @@ DocSearchEnvironmentTest >> testFirstOccurenceOfFourthChapterWithShiftedChapter 
 	self assert: docSearchEnv currentEntryIndex equals: 1.
 	self assert: docSearchEnv resultEntries size equals: 4.
 	self assert: docSearchEnv currentResultEntry chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv currentResultEntry startPosition equals: 12
+	self assert: docSearchEnv currentResultEntry startPosition equals: 11
 	
 ]
 
@@ -114,11 +114,11 @@ DocSearchEnvironmentTest >> testFirstResultEntriesForEachChapter [
 	res := docSearchEnv firstResultEntriesForEachChapters.
 	self assert: res size equals: 3.
 	self assert: res first chapter title  equals: 'chapitre 1'.
-	self assert: res first startPosition  equals: 12.
+	self assert: res first startPosition  equals: 11.
 	self assert: res second chapter title equals: 'chapitre 4'.
-	self assert: res second startPosition equals: 12.
+	self assert: res second startPosition equals: 11.
 	self assert: res third chapter title equals: 'chapitre 5'.
-	self assert: res third startPosition equals: 25
+	self assert: res third startPosition equals: 24
 ]
 
 { #category : #tests }
@@ -280,9 +280,9 @@ DocSearchEnvironmentTest >> testResultEntriesOf [
 	res := docSearchEnv resultEntriesOf: library books third chapters first key.
 	self assert: res size equals: 2.
 	self assert: res first chapter title  equals: 'chapitre 4'.
-	self assert: res first startPosition  equals: 12.
+	self assert: res first startPosition  equals: 11.
 	self assert: res second chapter title equals: 'chapitre 4'.
-	self assert: res second startPosition equals: 72
+	self assert: res second startPosition equals: 71
 ]
 
 { #category : #'tests-search' }
@@ -293,13 +293,13 @@ DocSearchEnvironmentTest >> testSearch [
 	docSearchEnv search: 'test'.
 	self assert: docSearchEnv resultEntries size equals: 4.
 	self assert: docSearchEnv resultEntries first chapter title equals: 'chapitre 1'.
-	self assert: docSearchEnv resultEntries first startPosition equals: 12.
+	self assert: docSearchEnv resultEntries first startPosition equals: 11.
 	self assert: docSearchEnv resultEntries second chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv resultEntries second startPosition equals: 12.
+	self assert: docSearchEnv resultEntries second startPosition equals: 11.
 	self assert: docSearchEnv resultEntries third chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv resultEntries third startPosition equals: 72.
+	self assert: docSearchEnv resultEntries third startPosition equals: 71.
 	self assert: docSearchEnv resultEntries fourth chapter title equals: 'chapitre 5'.
-	self assert: docSearchEnv resultEntries fourth startPosition equals: 25.
+	self assert: docSearchEnv resultEntries fourth startPosition equals: 24.
 	
 ]
 
@@ -310,11 +310,11 @@ DocSearchEnvironmentTest >> testSearchWithDocSearchRangeBeginAt14 [
 	docSearchEnv search: 'test'.
 	self assert: docSearchEnv resultEntries size equals: 3.
 	self assert: docSearchEnv resultEntries first chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv resultEntries first startPosition equals: 12.
+	self assert: docSearchEnv resultEntries first startPosition equals: 11.
 	self assert: docSearchEnv resultEntries second chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv resultEntries second startPosition equals: 72.
+	self assert: docSearchEnv resultEntries second startPosition equals: 71.
 	self assert: docSearchEnv resultEntries third chapter title equals: 'chapitre 5'.
-	self assert: docSearchEnv resultEntries third startPosition equals: 25.
+	self assert: docSearchEnv resultEntries third startPosition equals: 24.
 	
 ]
 
@@ -325,11 +325,11 @@ DocSearchEnvironmentTest >> testSearchWithDocSearchRangeBeginAt14WithShiftedChap
 	docSearchEnv search: 'test'.
 	self assert: docSearchEnv resultEntries size equals: 3.
 	self assert: docSearchEnv resultEntries first chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv resultEntries first startPosition equals: 72.
+	self assert: docSearchEnv resultEntries first startPosition equals: 71.
 	self assert: docSearchEnv resultEntries second chapter title equals: 'chapitre 5'.
-	self assert: docSearchEnv resultEntries second startPosition equals: 25.
+	self assert: docSearchEnv resultEntries second startPosition equals: 24.
 	self assert: docSearchEnv resultEntries third chapter title equals: 'chapitre 1'.
-	self assert: docSearchEnv resultEntries third startPosition equals: 12.
+	self assert: docSearchEnv resultEntries third startPosition equals: 11.
 
 	
 ]
@@ -341,13 +341,13 @@ DocSearchEnvironmentTest >> testSearchWithDocSearchRangeFinishAt14 [
 	docSearchEnv search: 'test'.
 		self assert: docSearchEnv resultEntries size equals: 4.
 	self assert: docSearchEnv resultEntries first chapter title equals: 'chapitre 1'.
-	self assert: docSearchEnv resultEntries first startPosition equals: 12.
+	self assert: docSearchEnv resultEntries first startPosition equals: 11.
 	self assert: docSearchEnv resultEntries second chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv resultEntries second startPosition equals: 12.
+	self assert: docSearchEnv resultEntries second startPosition equals: 11.
 	self assert: docSearchEnv resultEntries third chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv resultEntries third startPosition equals: 72.
+	self assert: docSearchEnv resultEntries third startPosition equals: 71.
 	self assert: docSearchEnv resultEntries fourth chapter title equals: 'chapitre 5'.
-	self assert: docSearchEnv resultEntries fourth startPosition equals: 25.
+	self assert: docSearchEnv resultEntries fourth startPosition equals: 24.
 	
 ]
 
@@ -427,12 +427,12 @@ DocSearchEnvironmentTest >> testSearchWithShiftedChapter [
 	self assert: docSearchEnv resultEntries size equals: 4.
 
 	self assert: docSearchEnv resultEntries first chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv resultEntries first startPosition equals: 12.
+	self assert: docSearchEnv resultEntries first startPosition equals: 11.
 	self assert: docSearchEnv resultEntries second chapter title equals: 'chapitre 4'.
-	self assert: docSearchEnv resultEntries second  startPosition equals: 72.
+	self assert: docSearchEnv resultEntries second  startPosition equals: 71.
 	self assert: docSearchEnv resultEntries third chapter title equals: 'chapitre 5'.
-	self assert: docSearchEnv resultEntries third startPosition equals: 25.
+	self assert: docSearchEnv resultEntries third startPosition equals: 24.
 	self assert: docSearchEnv resultEntries fourth chapter title equals: 'chapitre 1'.
-	self assert: docSearchEnv resultEntries fourth startPosition equals: 12.
+	self assert: docSearchEnv resultEntries fourth startPosition equals: 11.
 	
 ]

--- a/src/DocumentationSupport-UI/DocChapterPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocChapterPresenter.class.st
@@ -192,7 +192,7 @@ DocChapterPresenter >> initialize [
 ]
 
 { #category : #initialization }
-DocChapterPresenter >> initializePresenters [ 
+DocChapterPresenter >> initializePresenters [
 
 	super initializePresenters.
 	previewUpdateMutex := Mutex new.
@@ -204,67 +204,69 @@ DocChapterPresenter >> initializePresenters [
 	keyInput := self newTextInput.
 	keyInput enabled: false.
 	keyInput text: self chapter key.
-	
-	copyRefButton := self newButton 
-		label: 'ref://';
-		action: [ 
-			Clipboard clipboardText: '[', chapter title, '](ref://', self chapter key, ')' ].
+
+	copyRefButton := self newButton
+		                 label: 'ref://';
+		                 action: [ 
+			                 Clipboard clipboardText:
+					                 '[' , chapter title , '](ref://'
+					                 , self chapter key , ')' ].
 
 	copyIncludeButton := self newButton
-		label: 'include://';
-		action: [ 
-			Clipboard clipboardText: '[', chapter title, '](include://', self chapter key, ')' ].
+		                     label: 'include://';
+		                     action: [ 
+			                     Clipboard clipboardText:
+					                     '[' , chapter title , '](include://'
+					                     , self chapter key , ')' ].
 
 	srcInput := self newText.
 	preview := self getPreviewPresenter.
-	
+
 	preview morph setText: '' asText.
-	
-	srcInput text: self chapter source.	
+
+	srcInput text: self chapter source.
 
 	srcInput whenTextChangedDo: [ :newText | 
 		self chapter source: newText.
 		self updatePreview: newText ].
-	
+
 	chapter whenAspectChangedNotify: self.
-	
+
 	nextInput := self newTextInput.
-	nextInput text: (self chapter nextChapterText).
+	nextInput text: self chapter nextChapterText.
 	nextInput
-		enabled: false; 
+		enabled: false;
 		dropEnabled: true;
-		wantsDrop: [ :transfer | transfer passenger allSatisfy: [ :each | each isKindOf: DocChapter ] ];
-		acceptDrop: [ :transfer | 		
+		wantsDrop: [ :transfer | 
+			transfer passenger allSatisfy: [ :each | each isKindOf: DocChapter ] ];
+		acceptDrop: [ :transfer | 
 			| aChapter |
 			aChapter := transfer passenger anyOne.
 			self chapter nextChapter: aChapter.
 			nextInput text: aChapter title ].
 
 	clearNext := self newButton
-		icon: (self iconNamed: #changeRemove);
-		action: [ 
-			self chapter nextChapter: nil ].
-		
+		             icon: (self iconNamed: #changeRemove);
+		             action: [ self chapter nextChapter: nil ].
+
 	goToNext := self newButton
-		icon: (self iconNamed: #glamorousGo);
-		action: [ 
-			self chapter nextChapter ifNotNil: [ 
-				self openReference: (ZnUrl fromString: ('ref://', self chapter nextChapter key))] ].
-		
+		            icon: (self iconNamed: #glamorousGo);
+		            action: [ 
+			            self chapter nextChapter ifNotNil: [ 
+					            self openReference:
+							            (ZnUrl fromString:
+									             'ref://' , self chapter nextChapter key) ] ].
+
 	showEditor := false.
-	splitButton := self newButton 
-		icon: (self iconNamed: #edit);
-		action: [ 
-			showEditor := showEditor not.
-			layout := self layoutShowingEditor: showEditor ].
-	
+	splitButton := self newButton
+		               icon: (self iconNamed: #edit);
+		               action: [ self splitLayoutOrNot ].
+
 	headerEnable := false.
 	editEnable := false.
-	
+
 	layout := self layoutShowingEditor: showEditor.
 	self updatePreview: self chapter source
-
-
 ]
 
 { #category : #initialization }
@@ -294,7 +296,8 @@ DocChapterPresenter >> openChapterAction [
 	
 	presenter presenter headerShortcut: category;
 	editShortcut: category;
-	openShortcut: category
+	openShortcut: category;
+	showChapterShortcut: category
 ]
 
 { #category : #actions }
@@ -404,6 +407,14 @@ DocChapterPresenter >> setShowHeaderButton [
 	^ SpButtonPresenter new
 		label: 'Header hide/show';
 		action: [ self changeHeaderView ]
+]
+
+{ #category : #shortcuts }
+DocChapterPresenter >> showChapterShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #ShowChapterShortcut shortcut: $p meta shift mac | $p ctrl shift win | $p ctrl shift unix  action: [ 
+					 self splitLayoutOrNot. ])
 ]
 
 { #category : #initialization }

--- a/src/DocumentationSupport-UI/DocChapterPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocChapterPresenter.class.st
@@ -188,7 +188,7 @@ DocChapterPresenter >> headerShortcut: aCategory [
 { #category : #initialization }
 DocChapterPresenter >> initialize [
 	super initialize.
-	self setShortcut
+	self setShortcuts
 ]
 
 { #category : #initialization }
@@ -386,25 +386,16 @@ DocChapterPresenter >> setOpenButton [
 ]
 
 { #category : #shortcuts }
-DocChapterPresenter >> setShortcut [
+DocChapterPresenter >> setShortcuts [
 	| category morph |
-	preview ifNotNil: [ 
+	"preview ifNotNil: [ 
 		morph := preview morph.
 		category := KMCategory named: #DocChapterShortcut.
 		KMRepository default addCategory: category.
 		morph attachKeymapCategory: #DocChapterShortcut.
-		category
-			addKeymapEntry:
-				(KMKeymap named: #OpenShortcut shortcut: $o command mac | $o ctrl  win | $o ctrl unix | $o alt  action: [ self chapter asPresenter open ]);
-			addKeymapEntry:
-				(KMKeymap named: #OpenShortcut shortcut: $e command mac | $e ctrl  win | $e ctrl unix | $e alt  action: [ 
-					editEnable := editEnable not.
-					layout := self layoutShowingEditor: showEditor ]);
-			addKeymapEntry:
-				(KMKeymap named: #OpenShortcut shortcut: $h command mac | $h ctrl  win | $h ctrl unix | $h alt  action: [ 
-					headerEnable := headerEnable not.
-					layout := self layoutShowingEditor: showEditor ])
-		].
+		self openShortcut: category.
+		self headerShortcut: category.
+		self editShortcut: category ]"
 	
 ]
 

--- a/src/DocumentationSupport-UI/DocChapterPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocChapterPresenter.class.st
@@ -128,7 +128,7 @@ DocChapterPresenter >> editOrPreviewLayout: aBoolean [
 DocChapterPresenter >> editShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: $e command shift mac | $e ctrl shift win | $e ctrl shift unix  action: [ 
+				(KMKeymap named: #EditShortcut shortcut: $e meta shift mac | $e alt shift win | $e alt shift unix  action: [ 
 					editEnable := editEnable not.
 					layout := self layoutShowingEditor: showEditor ])
 ]
@@ -180,7 +180,7 @@ DocChapterPresenter >> headerLayout [
 DocChapterPresenter >> headerShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #HeaderShortcut shortcut: $h command shift mac | $h ctrl shift win | $h ctrl shift unix | $h alt  action: [ 
+				(KMKeymap named: #HeaderShortcut shortcut: $h meta shift mac | $h alt shift win | $h alt shift unix action: [ 
 					headerEnable := headerEnable not.
 					layout := self layoutShowingEditor: showEditor ])
 ]
@@ -322,7 +322,7 @@ DocChapterPresenter >> openReference: aRef [
 DocChapterPresenter >> openShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #OpenShortcut shortcut: $o command shift mac | $o ctrl shift win | $o ctrl shift unix | $o alt  action: [ self openChapterAction ])
+				(KMKeymap named: #OpenShortcut shortcut: $o meta shift mac | $o alt shift win | $o ctrl shift unix | $o alt  action: [ self openChapterAction ])
 ]
 
 { #category : #accessing }
@@ -413,7 +413,7 @@ DocChapterPresenter >> setShowHeaderButton [
 DocChapterPresenter >> showChapterShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #ShowChapterShortcut shortcut: $p meta shift mac | $p ctrl shift win | $p ctrl shift unix  action: [ 
+				(KMKeymap named: #ShowChapterShortcut shortcut: $p meta shift mac | $p alt shift win | $p alt shift unix  action: [ 
 					 self splitLayoutOrNot. ])
 ]
 

--- a/src/DocumentationSupport-UI/DocChapterPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocChapterPresenter.class.st
@@ -156,6 +156,12 @@ DocChapterPresenter >> headerLayout [
 ]
 
 { #category : #initialization }
+DocChapterPresenter >> initialize [
+	super initialize.
+	self setShortcut
+]
+
+{ #category : #initialization }
 DocChapterPresenter >> initializePresenters [ 
 
 	super initializePresenters.
@@ -327,6 +333,29 @@ DocChapterPresenter >> setOpenButton [
 	^ SpButtonPresenter new
 		label: 'Open';
 		action: [ self chapter asPresenter open ]
+]
+
+{ #category : #shortcuts }
+DocChapterPresenter >> setShortcut [
+	| category morph |
+	preview ifNotNil: [ 
+		morph := preview morph.
+		category := KMCategory named: #DocChapterShortcut.
+		KMRepository default addCategory: category.
+		morph attachKeymapCategory: #DocChapterShortcut.
+		category
+			addKeymapEntry:
+				(KMKeymap named: #OpenShortcut shortcut: $o command mac | $o ctrl  win | $o ctrl unix | $o alt  action: [ self chapter asPresenter open ]);
+			addKeymapEntry:
+				(KMKeymap named: #OpenShortcut shortcut: $e command mac | $e ctrl  win | $e ctrl unix | $e alt  action: [ 
+					editEnable := editEnable not.
+					layout := self layoutShowingEditor: showEditor ]);
+			addKeymapEntry:
+				(KMKeymap named: #OpenShortcut shortcut: $h command mac | $h ctrl  win | $h ctrl unix | $h alt  action: [ 
+					headerEnable := headerEnable not.
+					layout := self layoutShowingEditor: showEditor ])
+		].
+	
 ]
 
 { #category : #buttons }

--- a/src/DocumentationSupport-UI/DocChapterPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocChapterPresenter.class.st
@@ -124,6 +124,15 @@ DocChapterPresenter >> editOrPreviewLayout: aBoolean [
 	
 ]
 
+{ #category : #shortcuts }
+DocChapterPresenter >> editShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #EditShortcut shortcut: $e command shift mac | $e ctrl shift win | $e ctrl shift unix  action: [ 
+					editEnable := editEnable not.
+					layout := self layoutShowingEditor: showEditor ])
+]
+
 { #category : #preview }
 DocChapterPresenter >> getPreviewPresenter [ 
 
@@ -165,6 +174,15 @@ DocChapterPresenter >> headerLayout [
 			) at: 2@3 span: 4@1;
 			
 			yourself) height: 120
+]
+
+{ #category : #shortcuts }
+DocChapterPresenter >> headerShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #HeaderShortcut shortcut: $h command shift mac | $h ctrl shift win | $h ctrl shift unix | $h alt  action: [ 
+					headerEnable := headerEnable not.
+					layout := self layoutShowingEditor: showEditor ])
 ]
 
 { #category : #initialization }
@@ -264,6 +282,21 @@ DocChapterPresenter >> layoutShowingEditor: aBoolean [
 	^ self chapterLayout: (self editOrPreviewLayout: aBoolean)
 ]
 
+{ #category : #shortcuts }
+DocChapterPresenter >> openChapterAction [
+
+	| morph presenter category |
+	presenter := self chapter asPresenter open.
+	morph := presenter window submorphs last.
+	category := KMCategory named: #DocChapterShortcut.
+	KMRepository default addCategory: category.
+	morph attachKeymapCategory: #DocChapterShortcut.
+	
+	presenter presenter headerShortcut: category;
+	editShortcut: category;
+	openShortcut: category
+]
+
 { #category : #actions }
 DocChapterPresenter >> openReference: aRef [ 
 
@@ -280,6 +313,13 @@ DocChapterPresenter >> openReference: aRef [
 	
 
 	
+]
+
+{ #category : #shortcuts }
+DocChapterPresenter >> openShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #OpenShortcut shortcut: $o command shift mac | $o ctrl shift win | $o ctrl shift unix | $o alt  action: [ self openChapterAction ])
 ]
 
 { #category : #accessing }

--- a/src/DocumentationSupport-UI/DocChapterPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocChapterPresenter.class.st
@@ -64,6 +64,18 @@ DocChapterPresenter >> buttonLayout [
 		add: self setOpenButton
 ]
 
+{ #category : #buttons }
+DocChapterPresenter >> changeEditView [
+	editEnable := editEnable not.
+	layout := self layoutShowingEditor: showEditor
+]
+
+{ #category : #buttons }
+DocChapterPresenter >> changeHeaderView [
+	headerEnable := headerEnable not.
+	layout := self layoutShowingEditor: showEditor
+]
+
 { #category : #accessing }
 DocChapterPresenter >> chapter [
 
@@ -323,9 +335,7 @@ DocChapterPresenter >> scrollValue: aScrollValue [
 DocChapterPresenter >> setEditButton [
 	^ SpButtonPresenter new
 		label: 'Edit/Preview';
-		action: [ 
-			editEnable := editEnable not.
-			layout := self layoutShowingEditor: showEditor ]
+		action: [ self changeEditView ]
 ]
 
 { #category : #buttons }
@@ -362,9 +372,7 @@ DocChapterPresenter >> setShortcut [
 DocChapterPresenter >> setShowHeaderButton [
 	^ SpButtonPresenter new
 		label: 'Header hide/show';
-		action: [ 
-			headerEnable := headerEnable not.
-			layout := self layoutShowingEditor: showEditor ]
+		action: [ self changeHeaderView ]
 ]
 
 { #category : #accessing }

--- a/src/DocumentationSupport-UI/DocChapterPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocChapterPresenter.class.st
@@ -406,6 +406,13 @@ DocChapterPresenter >> setShowHeaderButton [
 		action: [ self changeHeaderView ]
 ]
 
+{ #category : #initialization }
+DocChapterPresenter >> splitLayoutOrNot [
+
+	showEditor := showEditor not.
+	^ layout := self layoutShowingEditor: showEditor
+]
+
 { #category : #accessing }
 DocChapterPresenter >> text [
 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -497,6 +497,14 @@ DocLibraryPresenter >> searchEnv [
 	^ searchEnv
 ]
 
+{ #category : #shortcuts }
+DocLibraryPresenter >> searchShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #SearchShortcut shortcut: $l ctrl shift mac | $l ctrl shift win | $l ctrl shift unix  action: [ 
+					 searchInput takeKeyboardFocus ])
+]
+
 { #category : #'search-buttons' }
 DocLibraryPresenter >> setChapterDropList [
 	chapterDropList := SpDropListPresenter new 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -278,6 +278,36 @@ DocLibraryPresenter >> nextAction [
 		ifFalse: [ self next ]
 ]
 
+{ #category : #'search-actions' }
+DocLibraryPresenter >> nextChapter [
+
+	^ searchEnv ifNotNil: [ [ 
+		  searchEnv nextChapterInResultEntries.
+		  actualChapter := searchEnv currentResultEntry chapter.
+		  searchInput owner clickAt.
+		  self updateOccurenceDisplay ]
+			  on: SubscriptOutOfBounds , MessageNotUnderstood
+			  do: [ "nothing" ] ]
+]
+
+{ #category : #shortcuts }
+DocLibraryPresenter >> nextChapterShortcut: aCategory [
+	self flag: #toFix.
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #EditShortcut shortcut: Character arrowUp command mac | Character arrowUp ctrl win | Character arrowUp ctrl unix  action: [ 
+					self editModeEnable ifFalse: [ self nextChapter ] ])
+]
+
+{ #category : #shortcuts }
+DocLibraryPresenter >> nextShortcut: aCategory [
+	self flag: #toFix.
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #EditShortcut shortcut: Character arrowRight alt mac | Character arrowRight alt win | Character arrowRight alt unix action: [ 
+					self editModeEnable ifFalse: [ self next ]  ])
+]
+
 { #category : #'instance creation' }
 DocLibraryPresenter >> open [
 	self layout 
@@ -346,6 +376,37 @@ DocLibraryPresenter >> prev [
 	self updateOccurenceDisplay
 ]
 
+{ #category : #'search-actions' }
+DocLibraryPresenter >> prevChapter [
+
+	^ searchEnv ifNotNil: [ 
+		  [ 
+		  searchEnv prevChapterInResultEntries.
+		  actualChapter := searchEnv currentResultEntry chapter.
+		  searchInput owner clickAt.
+		  self updateOccurenceDisplay ]
+			  on: SubscriptOutOfBounds , MessageNotUnderstood
+			  do: [ "nothing" ] ]
+]
+
+{ #category : #shortcuts }
+DocLibraryPresenter >> prevChapterShortcut: aCategory [
+	self flag: #toFix.
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #EditShortcut shortcut: Character arrowDown command mac | Character arrowDown ctrl win | Character arrowDown ctrl unix  action: [ 
+					self editModeEnable ifFalse: [ self prevChapter ] ])
+]
+
+{ #category : #shortcuts }
+DocLibraryPresenter >> prevShortcut: aCategory [
+	self flag: #toFix.
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #EditShortcut shortcut: Character arrowLeft command ctrl mac | Character arrowLeft alt win | Character arrowLeft alt unix action: [ 
+					self editModeEnable ifFalse: [ self prev ]  ])
+]
+
 { #category : #'parameters-bar' }
 DocLibraryPresenter >> refreshChapter [
 	[tree clickAtPath: actualChapterPresenter path] 
@@ -408,6 +469,15 @@ DocLibraryPresenter >> searchBar [
 DocLibraryPresenter >> searchEnv [
 
 	^ searchEnv
+]
+
+{ #category : #shortcuts }
+DocLibraryPresenter >> searchShortcut: aCategory [
+	self flag: #toFix.
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #EditShortcut shortcut: $l command shift mac | $l ctrl shift win | $l ctrl shift unix | $l alt  action: [ 
+					searchInput adapter takeKeyboardFocus ])
 ]
 
 { #category : #'search-buttons' }

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -275,6 +275,7 @@ DocLibraryPresenter >> open [
 			add: #editor expand: true fill: true  ;
 			yourself) expand: true.
 		super open.
+		self setShortcuts.
 ]
 
 { #category : #actions }
@@ -497,6 +498,20 @@ DocLibraryPresenter >> setSearchButton [
 							actualChapter := searchEnv currentResultEntry chapter.
 							searchInput owner clickAt.
 							] on: SubscriptOutOfBounds,MessageNotUnderstood  do: [ self clickAt ]  ]
+]
+
+{ #category : #shortcuts }
+DocLibraryPresenter >> setShortcuts [
+	| category morph |
+		morph := self owner window submorphs last.
+		category := KMCategory named: #DocChapterShortcut.
+		KMRepository default addCategory: category.
+		morph attachKeymapCategory: #DocChapterShortcut.
+		self openShortcut: category.
+		self headerShortcut: category.
+		self editShortcut: category.
+		self showShortcut: category
+	
 ]
 
 { #category : #tree }

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -565,7 +565,7 @@ DocLibraryPresenter >> setPreviousChapterButton [
 
 { #category : #'search-bar' }
 DocLibraryPresenter >> setSearchAction [
-	searchInput whenSubmitDo: [ 
+	searchInput whenSubmitDo: [ :t |
 		searchPattern = searchInput text 
 				ifTrue: [ 
 					searchEnv ifNotNil: [ [ self nextAction	] on: SubscriptOutOfBounds,MessageNotUnderstood  do: [ "nothing" ] ]

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -150,6 +150,14 @@ DocLibraryPresenter >> editModeEnable [
 	^ editCheckBox state
 ]
 
+{ #category : #shortcuts }
+DocLibraryPresenter >> editShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #EditShortcut shortcut: $e command shift mac | $e ctrl shift win | $e ctrl shift unix | $e alt  action: [ 
+					editCheckBox  state: editCheckBox state not ])
+]
+
 { #category : #actions }
 DocLibraryPresenter >> export [ 
 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -317,13 +317,6 @@ DocLibraryPresenter >> openInWindow: item [
 	item openIn: self application
 ]
 
-{ #category : #shortcuts }
-DocLibraryPresenter >> openShortcut: aCategory [
-	aCategory
-			addKeymapEntry:
-				(KMKeymap named: #OpenShortcut shortcut: $o command shift mac | $o ctrl shift win | $o ctrl shift unix | $o alt  action: [ self actualChapterPresenter chapter asPresenter open ])
-]
-
 { #category : #'parameters-bar' }
 DocLibraryPresenter >> parametersBar [
 	showHeaderCheckBox := SpCheckBoxPresenter new label: 'Show header'.
@@ -528,10 +521,12 @@ DocLibraryPresenter >> setShortcuts [
 		category := KMCategory named: #DocChapterShortcut.
 		KMRepository default addCategory: category.
 		morph attachKeymapCategory: #DocChapterShortcut.
-		self openShortcut: category.
-		self headerShortcut: category.
-		self editShortcut: category.
-		self showShortcut: category
+		self openChapterShortcut: category;
+		headerChapterShortcut: category;
+		editChapterShortcut: category;
+		headerShortcut: category;
+		editShortcut: category;
+		showShortcut: category.
 	
 ]
 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -612,10 +612,16 @@ DocLibraryPresenter >> setShortcuts [
 		editChapterShortcut: category;
 		showChapterShortcut: category.
 		
+		
 		"Set library shortcuts"
 		self headerShortcut: category;
 		editShortcut: category;
-		showShortcut: category
+		showShortcut: category;
+		nextShortcut: category;
+		prevShortcut: category;
+		nextChapterShortcut: category;
+		prevChapterShortcut: category;
+		searchShortcut: category
 ]
 
 { #category : #tree }

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -166,6 +166,14 @@ DocLibraryPresenter >> export [
 
 ]
 
+{ #category : #shortcuts }
+DocLibraryPresenter >> headerShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #HeaderShortcut shortcut: $h command shift mac | $h ctrl shift win | $h ctrl shift unix | $h alt  action: [ 
+					showHeaderCheckBox state: showHeaderCheckBox state not ])
+]
+
 { #category : #initialization }
 DocLibraryPresenter >> initializePresenters [ 
 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -528,6 +528,14 @@ DocLibraryPresenter >> showModeEnable [
 	^ showCheckBox state
 ]
 
+{ #category : #shortcuts }
+DocLibraryPresenter >> showShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #ShowShortcut shortcut: $p command shift mac | $p ctrl shift win | $p ctrl shift unix | $p alt  action: [ 
+					 showCheckBox state: showCheckBox state not ])
+]
+
 { #category : #actions }
 DocLibraryPresenter >> toolbarActions [
 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -291,6 +291,14 @@ DocLibraryPresenter >> nextChapter [
 ]
 
 { #category : #shortcuts }
+DocLibraryPresenter >> nextChapterShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #NextChapterShortcut shortcut: Character arrowUp ctrl shift mac | Character arrowUp ctrl shift win | Character arrowUp ctrl shift unix  action: [ 
+					 self nextChapter ])
+]
+
+{ #category : #shortcuts }
 DocLibraryPresenter >> nextShortcut: aCategory [
 	aCategory
 			addKeymapEntry:

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -565,7 +565,7 @@ DocLibraryPresenter >> setPreviousChapterButton [
 
 { #category : #'search-bar' }
 DocLibraryPresenter >> setSearchAction [
-	searchInput whenSubmitDo: [ :t |
+	searchInput whenSubmitDo: [ :null |
 		searchPattern = searchInput text 
 				ifTrue: [ 
 					searchEnv ifNotNil: [ [ self nextAction	] on: SubscriptOutOfBounds,MessageNotUnderstood  do: [ "nothing" ] ]

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -145,6 +145,13 @@ DocLibraryPresenter >> docSearchObject: aDocSearchObject [
 	docSearchObject := aDocSearchObject
 ]
 
+{ #category : #shortcuts }
+DocLibraryPresenter >> editChapterShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #EditChapterShortcut shortcut: $e ctrl shift mac | $e alt shift win | $e alt shift unix "| $e alt"  action: [ actualChapterPresenter changeEditView ])
+]
+
 { #category : #'parameters-bar' }
 DocLibraryPresenter >> editModeEnable [
 	^ editCheckBox state

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -303,7 +303,7 @@ DocLibraryPresenter >> nextShortcut: aCategory [
 	self flag: #toFix.
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: Character arrowRight alt mac | Character arrowRight alt win | Character arrowRight alt unix action: [ 
+				(KMKeymap named: #EditShortcut shortcut: Character arrowRight meta mac | Character arrowRight alt win | Character arrowRight alt unix action: [ 
 					self editModeEnable ifFalse: [ self next ]  ])
 ]
 
@@ -419,7 +419,7 @@ DocLibraryPresenter >> prevShortcut: aCategory [
 	self flag: #toFix.
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: Character arrowLeft command ctrl mac | Character arrowLeft alt win | Character arrowLeft alt unix action: [ 
+				(KMKeymap named: #EditShortcut shortcut: Character arrowLeft alt mac | Character arrowLeft alt win | Character arrowLeft alt unix action: [ 
 					self editModeEnable ifFalse: [ self prev ]  ])
 ]
 
@@ -492,7 +492,7 @@ DocLibraryPresenter >> searchShortcut: aCategory [
 	self flag: #toFix.
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: $l command shift mac | $l ctrl shift win | $l ctrl shift unix | $l alt  action: [ 
+				(KMKeymap named: #EditShortcut shortcut: $l command mac | $l ctrl shift win | $l ctrl shift unix  action: [ 
 					searchInput adapter takeKeyboardFocus ])
 ]
 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -295,6 +295,13 @@ DocLibraryPresenter >> openInWindow: item [
 	item openIn: self application
 ]
 
+{ #category : #shortcuts }
+DocLibraryPresenter >> openShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #OpenShortcut shortcut: $o command shift mac | $o ctrl shift win | $o ctrl shift unix | $o alt  action: [ self actualChapterPresenter chapter asPresenter open ])
+]
+
 { #category : #'parameters-bar' }
 DocLibraryPresenter >> parametersBar [
 	showHeaderCheckBox := SpCheckBoxPresenter new label: 'Show header'.

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -606,7 +606,7 @@ DocLibraryPresenter >> setupTreeMenu [
 DocLibraryPresenter >> showChapterShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #ShowChapterShortcut shortcut: $p meta shift mac | $p ctrl shift win | $p ctrl shift unix  action: [ 
+				(KMKeymap named: #ShowChapterShortcut shortcut: $p meta shift mac | $p alt shift win | $p alt shift unix  action: [ 
 					 actualChapterPresenter splitLayoutOrNot. ])
 ]
 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -149,7 +149,7 @@ DocLibraryPresenter >> docSearchObject: aDocSearchObject [
 DocLibraryPresenter >> editChapterShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #EditChapterShortcut shortcut: $e ctrl shift mac | $e alt shift win | $e alt shift unix "| $e alt"  action: [ actualChapterPresenter changeEditView ])
+				(KMKeymap named: #EditChapterShortcut shortcut: $e meta shift mac | $e alt shift win | $e alt shift unix "| $e alt"  action: [ actualChapterPresenter changeEditView ])
 ]
 
 { #category : #'parameters-bar' }
@@ -178,7 +178,7 @@ DocLibraryPresenter >> export [
 DocLibraryPresenter >> headerChapterShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #HeaderChapterShortcut shortcut: $h ctrl shift mac | $h alt shift win | $h alt shift unix "| $h alt"  action: [ actualChapterPresenter changeHeaderView ])
+				(KMKeymap named: #HeaderChapterShortcut shortcut: $h meta shift mac | $h alt shift win | $h alt shift unix "| $h alt"  action: [ actualChapterPresenter changeHeaderView ])
 ]
 
 { #category : #shortcuts }
@@ -336,10 +336,27 @@ DocLibraryPresenter >> openChapter: aKey [
 ]
 
 { #category : #'shortcuts-chapter' }
+DocLibraryPresenter >> openChapterAction [
+
+	| morph presenter category |
+	presenter := actualChapterPresenter chapter asPresenter open.
+	morph := presenter window submorphs last.
+	category := KMCategory named: #DocChapterShortcut.
+	KMRepository default addCategory: category.
+	morph attachKeymapCategory: #DocChapterShortcut.
+	
+	presenter presenter headerShortcut: category;
+	editShortcut: category;
+	openShortcut: category
+]
+
+{ #category : #'shortcuts-chapter' }
 DocLibraryPresenter >> openChapterShortcut: aCategory [
-	aCategory
-			addKeymapEntry:
-				(KMKeymap named: #OpenChapterShortcut shortcut: $o ctrl shift mac | $o alt shift win | $o alt shift unix "| $o alt"  action: [ actualChapterPresenter chapter asPresenter open ])
+
+	aCategory addKeymapEntry: (KMKeymap
+			 named: #OpenChapterShortcut
+			 shortcut: $o meta shift mac | $o alt shift win | $o alt shift unix
+			 action: [ self openChapterAction ])
 ]
 
 { #category : #actions }

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -597,21 +597,19 @@ DocLibraryPresenter >> setSearchButton [
 DocLibraryPresenter >> setShortcuts [
 	| category morph |
 		morph := self owner window submorphs last.
-		category := KMCategory named: #DocChapterShortcut.
+		category := KMCategory named: #DocLibraryShortcut.
 		KMRepository default addCategory: category.
-		morph attachKeymapCategory: #DocChapterShortcut.
+		morph attachKeymapCategory: #DocLibraryShortcut.
+		
+		"Set chapter shortcuts"
 		self openChapterShortcut: category;
-		headerChapterShortcut: category.
-		self editChapterShortcut: category;
-		headerShortcut: category;
+		headerChapterShortcut: category;
+		editChapterShortcut: category.
+		
+		"Set library shortcuts"
+		self headerShortcut: category;
 		editShortcut: category;
-		showShortcut: category;
-		nextShortcut: category;
-		prevShortcut: category;
-		nextChapterShortcut: category;
-		prevChapterShortcut: category;
-		searchShortcut: category 
-	
+		showShortcut: category
 ]
 
 { #category : #tree }

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -371,8 +371,18 @@ DocLibraryPresenter >> prev [
 		ifFalse: [ 
 			actualChapter := searchEnv currentResultEntry chapter.
 			searchInput owner clickAt.
-			hasPrevChapterChange := true ].
+			hasPrevChapterChange := true.
+			self updateText: searchEnv currentResultEntry ].
 	self updateOccurenceDisplay
+]
+
+{ #category : #'search-actions' }
+DocLibraryPresenter >> prevAction [
+	self prev.
+	^ hasPrevChapterChange
+		  ifTrue: [ 
+			  actualChapterPresenter scrollValue: searchEnv currentResultEntry scrollValue.
+			  hasPrevChapterChange := false ]
 ]
 
 { #category : #'search-actions' }
@@ -496,14 +506,10 @@ DocLibraryPresenter >> setNextChapterButton [
 
 { #category : #'search-buttons' }
 DocLibraryPresenter >> setPreviousButton [
+
 	^ SpButtonPresenter new
-	  	label: 'Previous';
-		action: [ searchEnv ifNotNil: [ [ 
-			hasPrevChapterChange  
-				ifTrue: [ 
-					actualChapterPresenter scrollValue: searchEnv currentResultEntry scrollValue. 
-					hasPrevChapterChange := false ] 
-				ifFalse: [ self prev ]] on: SubscriptOutOfBounds,MessageNotUnderstood  do: [ "nothing" ] ]  ]
+		  label: 'Previous';
+		  action: [ searchEnv ifNotNil: [ [ self prevAction ]  on: SubscriptOutOfBounds , MessageNotUnderstood do: [ "nothing" ] ] ]
 ]
 
 { #category : #'search-buttons' }

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -264,17 +264,18 @@ DocLibraryPresenter >> next [
 		ifFalse: [ 
 			actualChapter := searchEnv currentResultEntry chapter.
 			searchInput owner clickAt.
-			hasNextChapterChange := true ].
+			hasNextChapterChange := true.
+			self updateText: searchEnv currentResultEntry ].
 	self updateOccurenceDisplay
 ]
 
 { #category : #'search-actions' }
 DocLibraryPresenter >> nextAction [
+	self next.
 	hasNextChapterChange 
-		ifTrue: [ 
+		ifTrue: [ 			
 			actualChapterPresenter scrollValue: searchEnv currentResultEntry scrollValue. 
 			hasNextChapterChange := false ] 
-		ifFalse: [ self next ]
 ]
 
 { #category : #'search-actions' }

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -304,6 +304,13 @@ DocLibraryPresenter >> openChapter: aKey [
 
 ]
 
+{ #category : #shortcuts }
+DocLibraryPresenter >> openChapterShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #OpenChapterShortcut shortcut: $o ctrl shift mac | $o alt shift win | $o alt shift unix "| $o alt"  action: [ actualChapterPresenter chapter asPresenter open ])
+]
+
 { #category : #actions }
 DocLibraryPresenter >> openInWindow: item [
 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -289,24 +289,6 @@ DocLibraryPresenter >> nextChapter [
 			  do: [ "nothing" ] ]
 ]
 
-{ #category : #shortcuts }
-DocLibraryPresenter >> nextChapterShortcut: aCategory [
-	self flag: #toFix.
-	aCategory
-			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: Character arrowUp command mac | Character arrowUp ctrl win | Character arrowUp ctrl unix  action: [ 
-					self editModeEnable ifFalse: [ self nextChapter ] ])
-]
-
-{ #category : #shortcuts }
-DocLibraryPresenter >> nextShortcut: aCategory [
-	self flag: #toFix.
-	aCategory
-			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: Character arrowRight meta mac | Character arrowRight alt win | Character arrowRight alt unix action: [ 
-					self editModeEnable ifFalse: [ self next ]  ])
-]
-
 { #category : #'instance creation' }
 DocLibraryPresenter >> open [
 	self layout 
@@ -405,24 +387,6 @@ DocLibraryPresenter >> prevChapter [
 			  do: [ "nothing" ] ]
 ]
 
-{ #category : #shortcuts }
-DocLibraryPresenter >> prevChapterShortcut: aCategory [
-	self flag: #toFix.
-	aCategory
-			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: Character arrowDown command mac | Character arrowDown ctrl win | Character arrowDown ctrl unix  action: [ 
-					self editModeEnable ifFalse: [ self prevChapter ] ])
-]
-
-{ #category : #shortcuts }
-DocLibraryPresenter >> prevShortcut: aCategory [
-	self flag: #toFix.
-	aCategory
-			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: Character arrowLeft alt mac | Character arrowLeft alt win | Character arrowLeft alt unix action: [ 
-					self editModeEnable ifFalse: [ self prev ]  ])
-]
-
 { #category : #'parameters-bar' }
 DocLibraryPresenter >> refreshChapter [
 	[tree clickAtPath: actualChapterPresenter path] 
@@ -485,15 +449,6 @@ DocLibraryPresenter >> searchBar [
 DocLibraryPresenter >> searchEnv [
 
 	^ searchEnv
-]
-
-{ #category : #shortcuts }
-DocLibraryPresenter >> searchShortcut: aCategory [
-	self flag: #toFix.
-	aCategory
-			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: $l command mac | $l ctrl shift win | $l ctrl shift unix  action: [ 
-					searchInput adapter takeKeyboardFocus ])
 ]
 
 { #category : #'search-buttons' }

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -174,6 +174,13 @@ DocLibraryPresenter >> export [
 ]
 
 { #category : #shortcuts }
+DocLibraryPresenter >> headerChapterShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #HeaderChapterShortcut shortcut: $h ctrl shift mac | $h alt shift win | $h alt shift unix "| $h alt"  action: [ actualChapterPresenter changeHeaderView ])
+]
+
+{ #category : #shortcuts }
 DocLibraryPresenter >> headerShortcut: aCategory [
 	aCategory
 			addKeymapEntry:

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -408,6 +408,15 @@ DocLibraryPresenter >> prevChapter [
 			  do: [ "nothing" ] ]
 ]
 
+{ #category : #shortcuts }
+DocLibraryPresenter >> prevShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #PrevShortcut shortcut: Character arrowLeft ctrl shift mac | Character arrowLeft ctrl shift win | Character arrowLeft ctrl shift unix  action: [ 
+					 searchEnv 
+						ifNotNil: [ [ self prevAction ] on: SubscriptOutOfBounds,MessageNotUnderstood  do: [ "nothing" ] ] ])
+]
+
 { #category : #'parameters-bar' }
 DocLibraryPresenter >> refreshChapter [
 	[tree clickAtPath: actualChapterPresenter path] 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -640,8 +640,10 @@ DocLibraryPresenter >> updateOccurenceDisplay [
 
 { #category : #'search-bar' }
 DocLibraryPresenter >> updateText: previousEntry [
-	| text |
+	| text tmpPresenter |
+	tmpPresenter := actualChapter asPresenter.
 	text := actualChapterPresenter text.
+	actualChapterPresenter chapter key = actualChapter key ifFalse: [ text := tmpPresenter text ].
 	text addAttribute: (TextBackgroundColor new color: Color lightGray) from: previousEntry startPosition to: previousEntry endPosition.
 	text addAttribute: (TextBackgroundColor new color: Color green) from: searchEnv currentResultEntry startPosition to: searchEnv currentResultEntry endPosition.
 	actualChapterPresenter updateText: text	scrollAt: searchEnv currentResultEntry scrollValue

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -159,10 +159,9 @@ DocLibraryPresenter >> editModeEnable [
 
 { #category : #shortcuts }
 DocLibraryPresenter >> editShortcut: aCategory [
-	self flag: #toFix.
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: $e ctrl mac | $m ctrl shift win | $e ctrl shift unix | $e alt  action: [ 
+				(KMKeymap named: #EditShortcut shortcut: $e ctrl shift mac | $e ctrl shift win | $e ctrl shift unix  action: [ 
 					editCheckBox state: editCheckBox state not ])
 ]
 
@@ -185,7 +184,7 @@ DocLibraryPresenter >> headerChapterShortcut: aCategory [
 DocLibraryPresenter >> headerShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #HeaderShortcut shortcut: $h ctrl mac | $h ctrl shift win | $h ctrl shift unix | $h alt  action: [ 
+				(KMKeymap named: #HeaderShortcut shortcut: $h ctrl shift mac | $h ctrl shift win | $h ctrl shift unix | $h alt  action: [ 
 					showHeaderCheckBox state: showHeaderCheckBox state not ])
 ]
 
@@ -653,10 +652,9 @@ DocLibraryPresenter >> showModeEnable [
 
 { #category : #shortcuts }
 DocLibraryPresenter >> showShortcut: aCategory [
-	self flag: #toFix.
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #ShowShortcut shortcut: $p command shift mac | $p ctrl shift win | $p ctrl shift unix | $p alt  action: [ 
+				(KMKeymap named: #ShowShortcut shortcut: $p ctrl shift mac | $p ctrl shift win | $p ctrl shift unix  action: [ 
 					 showCheckBox state: showCheckBox state not ])
 ]
 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -329,7 +329,8 @@ DocLibraryPresenter >> openChapterAction [
 	
 	presenter presenter headerShortcut: category;
 	editShortcut: category;
-	openShortcut: category
+	openShortcut: category;
+	showChapterShortcut: category
 ]
 
 { #category : #'shortcuts-chapter' }
@@ -566,7 +567,8 @@ DocLibraryPresenter >> setShortcuts [
 		"Set chapter shortcuts"
 		self openChapterShortcut: category;
 		headerChapterShortcut: category;
-		editChapterShortcut: category.
+		editChapterShortcut: category;
+		showChapterShortcut: category.
 		
 		"Set library shortcuts"
 		self headerShortcut: category;
@@ -598,6 +600,14 @@ DocLibraryPresenter >> setupTreeMenu [
 
 	tree contextMenu: treeMenu.
 
+]
+
+{ #category : #'shortcuts-chapter' }
+DocLibraryPresenter >> showChapterShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #ShowChapterShortcut shortcut: $p meta shift mac | $p ctrl shift win | $p ctrl shift unix  action: [ 
+					 actualChapterPresenter splitLayoutOrNot. ])
 ]
 
 { #category : #'parameters-bar' }

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -290,6 +290,15 @@ DocLibraryPresenter >> nextChapter [
 			  do: [ "nothing" ] ]
 ]
 
+{ #category : #shortcuts }
+DocLibraryPresenter >> nextShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #NextShortcut shortcut: Character arrowRight ctrl shift mac | Character arrowRight ctrl shift win | Character arrowRight ctrl shift unix  action: [ 
+					 searchEnv 
+						ifNotNil: [ [ self nextAction ] on: SubscriptOutOfBounds,MessageNotUnderstood  do: [ "nothing" ] ] ])
+]
+
 { #category : #'instance creation' }
 DocLibraryPresenter >> open [
 	self layout 

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -417,6 +417,14 @@ DocLibraryPresenter >> prevChapter [
 ]
 
 { #category : #shortcuts }
+DocLibraryPresenter >> prevChapterShortcut: aCategory [
+	aCategory
+			addKeymapEntry:
+				(KMKeymap named: #PrevChapterShortcut shortcut: Character arrowDown ctrl shift mac | Character arrowDown ctrl shift win | Character arrowDown ctrl shift unix  action: [ 
+					 self prevChapter ])
+]
+
+{ #category : #shortcuts }
 DocLibraryPresenter >> prevShortcut: aCategory [
 	aCategory
 			addKeymapEntry:

--- a/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
+++ b/src/DocumentationSupport-UI/DocLibraryPresenter.class.st
@@ -145,7 +145,7 @@ DocLibraryPresenter >> docSearchObject: aDocSearchObject [
 	docSearchObject := aDocSearchObject
 ]
 
-{ #category : #shortcuts }
+{ #category : #'shortcuts-chapter' }
 DocLibraryPresenter >> editChapterShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
@@ -159,10 +159,11 @@ DocLibraryPresenter >> editModeEnable [
 
 { #category : #shortcuts }
 DocLibraryPresenter >> editShortcut: aCategory [
+	self flag: #toFix.
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #EditShortcut shortcut: $e command shift mac | $e ctrl shift win | $e ctrl shift unix | $e alt  action: [ 
-					editCheckBox  state: editCheckBox state not ])
+				(KMKeymap named: #EditShortcut shortcut: $e ctrl mac | $m ctrl shift win | $e ctrl shift unix | $e alt  action: [ 
+					editCheckBox state: editCheckBox state not ])
 ]
 
 { #category : #actions }
@@ -173,7 +174,7 @@ DocLibraryPresenter >> export [
 
 ]
 
-{ #category : #shortcuts }
+{ #category : #'shortcuts-chapter' }
 DocLibraryPresenter >> headerChapterShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
@@ -184,7 +185,7 @@ DocLibraryPresenter >> headerChapterShortcut: aCategory [
 DocLibraryPresenter >> headerShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
-				(KMKeymap named: #HeaderShortcut shortcut: $h command shift mac | $h ctrl shift win | $h ctrl shift unix | $h alt  action: [ 
+				(KMKeymap named: #HeaderShortcut shortcut: $h ctrl mac | $h ctrl shift win | $h ctrl shift unix | $h alt  action: [ 
 					showHeaderCheckBox state: showHeaderCheckBox state not ])
 ]
 
@@ -304,7 +305,7 @@ DocLibraryPresenter >> openChapter: aKey [
 
 ]
 
-{ #category : #shortcuts }
+{ #category : #'shortcuts-chapter' }
 DocLibraryPresenter >> openChapterShortcut: aCategory [
 	aCategory
 			addKeymapEntry:
@@ -445,14 +446,10 @@ DocLibraryPresenter >> setNextButton [
 
 { #category : #'search-buttons' }
 DocLibraryPresenter >> setNextChapterButton [
+
 	^ SpButtonPresenter new
-				     label: 'Next chapter';
-				     action: [ 
-							searchEnv ifNotNil: [ [ 
-							searchEnv nextChapterInResultEntries.
-							actualChapter := searchEnv currentResultEntry chapter.
-							searchInput owner clickAt.
-							self updateOccurenceDisplay ] on: SubscriptOutOfBounds,MessageNotUnderstood  do: [ "nothing" ] ]  ]
+		  label: 'Next chapter';
+		  action: [ self nextChapter ]
 ]
 
 { #category : #'search-buttons' }
@@ -469,14 +466,10 @@ DocLibraryPresenter >> setPreviousButton [
 
 { #category : #'search-buttons' }
 DocLibraryPresenter >> setPreviousChapterButton [
+
 	^ SpButtonPresenter new
-				     label: 'Previous chapter';
-				     action: [ 
-							searchEnv ifNotNil: [ [ 
-							searchEnv prevChapterInResultEntries.
-							actualChapter := searchEnv currentResultEntry chapter.
-							searchInput owner clickAt.
-							self updateOccurenceDisplay ] on: SubscriptOutOfBounds,MessageNotUnderstood  do: [ "nothing" ] ]  ]
+		  label: 'Previous chapter';
+		  action: [ self prevChapter ]
 ]
 
 { #category : #'search-bar' }
@@ -522,11 +515,16 @@ DocLibraryPresenter >> setShortcuts [
 		KMRepository default addCategory: category.
 		morph attachKeymapCategory: #DocChapterShortcut.
 		self openChapterShortcut: category;
-		headerChapterShortcut: category;
-		editChapterShortcut: category;
+		headerChapterShortcut: category.
+		self editChapterShortcut: category;
 		headerShortcut: category;
 		editShortcut: category;
-		showShortcut: category.
+		showShortcut: category;
+		nextShortcut: category;
+		prevShortcut: category;
+		nextChapterShortcut: category;
+		prevChapterShortcut: category;
+		searchShortcut: category 
 	
 ]
 
@@ -568,6 +566,7 @@ DocLibraryPresenter >> showModeEnable [
 
 { #category : #shortcuts }
 DocLibraryPresenter >> showShortcut: aCategory [
+	self flag: #toFix.
 	aCategory
 			addKeymapEntry:
 				(KMKeymap named: #ShowShortcut shortcut: $p command shift mac | $p ctrl shift win | $p ctrl shift unix | $p alt  action: [ 


### PR DESCRIPTION
# Shortcuts

OSX : `meta`
Unix/Windows : `alt`

## Chapter

- hide/show header `meta/alt + shift + h`
- edit/preview `meta/alt + shift + e`
- split window `meta/alt + shift + p`
- open chapter presenter `meta/alt + shift + o`

## Library

- hide/show header`ctrl + shift + h`
- edit/preview`ctrl + shift + e`
- split window `ctrl + shift + p`
- go to search bar `ctrl + shift + l`
- next `ctrl + shift + arrowRight`
- prev `ctrl + shift + arrowLeft`
- nextChapter `ctrl + shift + arrowUp`
- prevChapter `ctrl + shift + arrowDown`